### PR TITLE
Fixed chatline colors

### DIFF
--- a/mods/sa/metrics.yaml
+++ b/mods/sa/metrics.yaml
@@ -10,6 +10,8 @@ Metrics:
 	ClickSound: ClickSound
 	ClickDisabledSound: ClickSound
 	ChatLineSound: ChatLine
+	ChatMessageColor: FFFFFF
+	SystemMessageColor: FFFF00
 	WidgetDefaultCursor: default
 	WidgetSelectCursor: select
 	DefaultCursor: default


### PR DESCRIPTION
They seem to default to black when unset, which is very hard to read.