### PR TITLE
Added the damaged attack sequence for the Venus fly traps

### DIFF
--- a/mods/sa/rules/creep-plants.yaml
+++ b/mods/sa/rules/creep-plants.yaml
@@ -54,16 +54,17 @@ venus:
 		HP: 30000
 	Armament:
 		Weapon: venus
-	#WithAttackAnimation@normal:
-	#	Sequence: shoot
-	#	RequiresCondition: !injured
-	#WithAttackAnimation@injured:
-	#	Sequence: damaged-shoot
-	#	RequiresCondition: scratched
-	#GrantConditionOnDamageState: #TODO lack of support lightly damaged state
-	#	Condition: scratched
-	#	ValidDamageStates: Injured
-	#	GrantPermanently: False
+	-WithAttackAnimation:
+	WithAttackAnimation@normal:
+		Sequence: shoot
+		RequiresCondition: !scratched
+	WithAttackAnimation@injured:
+		Sequence: damaged-shoot
+		RequiresCondition: scratched
+	GrantConditionOnDamageState@SCRATCHED:
+		Condition: scratched
+		ValidDamageStates: Light, Medium, Heavy, Critical
+		GrantPermanently: False
 	-WithTurretAttackAnimation:
 	-WithSpriteTurret:
 	Plant:


### PR DESCRIPTION
The conditions setup was just slightly incorrect and the valid damage states are:

```csharp
	public enum DamageState
	{
		Undamaged = 1,
		Light = 2,
		Medium = 4,
		Heavy = 8,
		Critical = 16,
		Dead = 32
	}
```

