### PR TITLE
Fixed bots not using network orders to stop production

### DIFF
--- a/OpenRA.Mods.OpenSA/Traits/BotModules/HealColonyBotModule.cs
+++ b/OpenRA.Mods.OpenSA/Traits/BotModules/HealColonyBotModule.cs
@@ -33,7 +33,11 @@ namespace OpenRA.Mods.OpenSA.Traits
 			{
 				var health = colony.Trait<IHealth>();
 				if (health.DamageState == Info.DamageState)
-					colony.Trait<Colony>().CancelProductions(colony);
+				{
+					var queue = colony.Trait<ProductionQueue>();
+					foreach (var current in queue.AllQueued())
+						bot.QueueOrder(Order.CancelProduction(queue.Actor, current.Item, 1));
+				}
 			}
 		}
 	}

--- a/OpenRA.Mods.OpenSA/Traits/Colony/Colony.cs
+++ b/OpenRA.Mods.OpenSA/Traits/Colony/Colony.cs
@@ -55,22 +55,5 @@ namespace OpenRA.Mods.OpenSA.Traits
 
 			self.World.AddFrameEndTask(w => w.CreateActor(info.SpawnsActor, td));
 		}
-
-		public void CancelProductions(Actor self)
-		{
-			foreach (var productionQueue in self.TraitsImplementing<ProductionQueue>())
-			{
-				while (true)
-				{
-					var producing = productionQueue.AllQueued().ToArray();
-
-					if (!producing.Any())
-						break;
-
-					foreach (var productionItem in producing)
-						productionQueue.EndProduction(productionItem);
-				}
-			}
-		}
 	}
 }


### PR DESCRIPTION
I suspect this will fix https://github.com/Dzierzan/OpenSA/issues/154. This was introduced in https://github.com/Dzierzan/OpenSA/pull/70 and I suspect it will desync, because the production halt is only calculated locally and not in the network stream. When loading the replay / save it will desync as production and health of the colonies differ from the expected value.