### PR TITLE
Fixed support directory location

### DIFF
--- a/mods/sa/installer/downloads.yaml
+++ b/mods/sa/installer/downloads.yaml
@@ -2,11 +2,11 @@ basefiles: Base game files
 	SHA1: e3f2e9231752a42581f15d52f090f7d96d716876
 	MirrorList: https://gist.githubusercontent.com/Dzierzan/842bbd4f1beb35c3ba840373d615f118/raw/c350afb07edd4f4222502a5d9dc2936abb7945cc/gistfile1.txt
 	Extract:
-		^Content/sa/Sprites/Game.ANI: Game/Game.ANI
-		^Content/sa/Sprites/Game.DDF: Game/Game.DDF
-		^Content/sa/Sprites/Game.MIN: Game/Game.MIN
-		^Content/sa/Sounds/Game.SDF: Game/Game.SDF
-		^Content/sa/Sprites/Start.ANI: Start/Start.ANI
-		^Content/sa/Sprites/Start.DDF: Start/Start.DDF
-		^Content/sa/Sprites/Start.MIN: Start/Start.MIN
-		^Content/sa/Sounds/Start.SDF: Start/Start.SDF
+		^SupportDir|Content/sa/Sprites/Game.ANI: Game/Game.ANI
+		^SupportDir|Content/sa/Sprites/Game.DDF: Game/Game.DDF
+		^SupportDir|Content/sa/Sprites/Game.MIN: Game/Game.MIN
+		^SupportDir|Content/sa/Sounds/Game.SDF: Game/Game.SDF
+		^SupportDir|Content/sa/Sprites/Start.ANI: Start/Start.ANI
+		^SupportDir|Content/sa/Sprites/Start.DDF: Start/Start.DDF
+		^SupportDir|Content/sa/Sprites/Start.MIN: Start/Start.MIN
+		^SupportDir|Content/sa/Sounds/Start.SDF: Start/Start.SDF

--- a/mods/sa/mod.yaml
+++ b/mods/sa/mod.yaml
@@ -146,7 +146,7 @@ ChromeLayout:
 	common|chrome/gamesave-loading.yaml
 
 AssetBrowser:
-	SupportedExtensions: .ani, .ddf
+	SupportedExtensions: .ddf
 
 WebServices:
 	GameNews: https://localhost/gamenews # TODO

--- a/mods/sa/mod.yaml
+++ b/mods/sa/mod.yaml
@@ -6,7 +6,7 @@ Metadata:
 PackageFormats: SdfPackage, DdfPackage
 
 Packages:
-	~^Content/sa/
+	~^SupportDir|Content/sa/
 	^EngineDir
 	$sa: sa
 	^EngineDir|mods/common: common
@@ -270,7 +270,7 @@ ModContent:
 	HeaderMessage: Game content may be extracted from an existing installation.
 	Packages:
 		base: Base Game Files
-			TestFiles: ^Content/sa/Sprites/Game.ANI, ^Content/sa/Sprites/Game.DDF, ^Content/sa/Sprites/Game.MIN, ^Content/sa/Sounds/Game.SDF, ^Content/sa/Sprites/Start.ANI, ^Content/sa/Sprites/Start.DDF, ^Content/sa/Sprites/Start.MIN, ^Content/sa/Sounds/Start.SDF
+			TestFiles: ^SupportDir|Content/sa/Sprites/Game.ANI, ^SupportDir|Content/sa/Sprites/Game.DDF, ^SupportDir|Content/sa/Sprites/Game.MIN, ^SupportDir|Content/sa/Sounds/Game.SDF, ^SupportDir|Content/sa/Sprites/Start.ANI, ^SupportDir|Content/sa/Sprites/Start.DDF, ^SupportDir|Content/sa/Sprites/Start.MIN, ^SupportDir|Content/sa/Sounds/Start.SDF
 			Required: true
 			Download: basefiles
 			Sources: gate5


### PR DESCRIPTION
Followup of https://github.com/Dzierzan/OpenSA/pull/170. At the moment the directory is created inside the engine folder.